### PR TITLE
Add postgres to tf backend

### DIFF
--- a/charts/terraform-backend/Chart.lock
+++ b/charts/terraform-backend/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.5.4
-digest: sha256:ec899572c18ee7223eb9da19fc2e52e4ef59ea4b70abe719a5f6c15f7ed60b53
-generated: "2022-03-21T20:49:29.486567+01:00"
+  version: 16.13.2
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.9.1
+digest: sha256:3eb8738e114fc4ba04f36ffb236153ad62f09dee26654450803cd7a0b7fce9db
+generated: "2022-09-27T00:02:37.392355031+02:00"

--- a/charts/terraform-backend/Chart.yaml
+++ b/charts/terraform-backend/Chart.yaml
@@ -30,10 +30,16 @@ dependencies:
     version: 16.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
+  - name: postgresql
+    version: 11.x.x
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
 
 maintainers:
   - name: lu1as
     email: lukas.steiner@steinheilig.de
+  - name: tobikris
+    email: tobias.krischer@elyxon.de
 
 sources:
   - https://github.com/nimbolus/helm-charts/tree/main/charts/terraform-backend

--- a/charts/terraform-backend/templates/deployment.yaml
+++ b/charts/terraform-backend/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               value: {{ include "terraform-backend.fullname" . }}-redis-master:6379
           {{- end }}
           {{- end }}
+          {{- if .Values.postgresql.enabled }}
+            - name: POSTGRES_CONNECTION
+              value: postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ include "terraform-backend.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/terraform-backend/values.yaml
+++ b/charts/terraform-backend/values.yaml
@@ -100,7 +100,8 @@ env:
   # TLS_KEY: /var/run/secrets/tls/tls.key
   # TLS_CERT: /var/run/secrets/tls/tls.crt
 
-envValueFrom: {}
+envValueFrom:
+  {}
   # KMS_KEY:
   #   secretKeyRef:
   #     name: terraform-backend-kms-key
@@ -112,17 +113,20 @@ persistence:
     - ReadWriteOnce
   size: 10G
 
-extraVolumes: []
+extraVolumes:
+  []
   # - name: tls
   #   secret:
   #     secretName: terraform-backend-tls
 
-extraVolumeMounts: []
+extraVolumeMounts:
+  []
   # - name: tls
   #   mountPath: /var/run/secrets/tls
   #   readOnly: true
 
-hostAliases: []
+hostAliases:
+  []
   # - ip: "127.0.0.1"
   #   hostnames:
   #   - "foo.local"
@@ -133,3 +137,30 @@ redis:
   architecture: standalone
   global:
     password: secret
+
+externalRedis:
+  host: localhost
+  port: 6379
+  username: ""
+  password: ""
+  existingSecret: ""
+  existingSecretPasswordKey: ""
+
+postgresql:
+  enabled: false
+  architecture: standalone
+  auth:
+    enablePostgresUser: false
+    username: terraform_backend
+    password: ""
+    database: terraform_backend
+    existingSecret: ""
+
+externalPostgresql:
+  host: localhost
+  port: 5432
+  user: terraform_backend
+  password: ""
+  database: terraform_backend
+  existingSecret: ""
+  existingSecretPasswordKey: ""


### PR DESCRIPTION
This adds Postgres as a dependency to the WIP terraform-backend chart.
I included externalRedis and externalDatabase in the values but they are not currently used in the templates.
The plan is to allow the user to specify external databases instead.