### PR TITLE
fix: system-upgrade-controller crb name

### DIFF
--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/system-upgrade-controller/templates/clusterrolebinding.yaml
+++ b/charts/system-upgrade-controller/templates/clusterrolebinding.yaml
@@ -16,7 +16,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system-upgrade
+  name: system-upgrade-controller
   labels:
     {{- include "system-upgrade-controller.labels" . | nindent 4 }}
 roleRef:


### PR DESCRIPTION
Renames the cluster role binding to allow upgrades from the version 0.3.1 (see https://github.com/rancher/system-upgrade-controller/issues/294 for upstream bug). Helm will automatically delete the old cluster role binding, so no manual changes are required.

Fixes #17